### PR TITLE
Updating the OAuth 2.0 Scope Functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ dump.rdb
 transaction-logs
 docker-build-local.sh
 *.tar
+.vscode

--- a/.gitlab-aws.yml
+++ b/.gitlab-aws.yml
@@ -1,12 +1,3 @@
-image: docker:stable
-
-services:
-  - docker:dind
-
-variables:
-  DOCKER_DRIVER: overlay2
-  DOCKER_HOST: tcp://localhost:2375
-
 stages:
   - build
   - deploy
@@ -16,9 +7,6 @@ build:
   stage: build
   only:
     - master
-  before_script:
-    - apk add --no-cache curl jq python py-pip make
-    - pip install awscli docker-compose
   script:
     - make docker-build
     - docker tag $CI_PROJECT_NAME $DOCKER_ORG/$CI_PROJECT_NAME:latest
@@ -32,12 +20,8 @@ build:
 
 deploy:
   stage: deploy
-  image: roffe/kubectl
   only:
     - master
-  before_script:
-    - mkdir -p $HOME/.kube
-    - echo -n $KUBE_CONFIG | base64 -d > $HOME/.kube/config
   script:
     - kubectl set image deployment/$CI_PROJECT_NAME $CI_PROJECT_NAME=$DOCKER_ORG/$CI_PROJECT_NAME:latest
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 docker-build:
+	docker-compose pull
 	docker-compose up -d
 	docker build \
 		-t fdns-ms-cda-utils \

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ This microservice is designed to be used with other microservices. Please look a
 
 This microservice is configurable so that it can be secured via an OAuth 2 provider.
 
-__Scopes__: This application uses the following scope: `cda-utils`
+__Scopes__: This application uses the following scope: `fdns.cda-utils`
 
 Please see the following environment variables for configuring with your OAuth 2 provider:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,3 +4,7 @@ services:
     image: fluent/fluentd
     ports:
       - "24224:24224"
+  fdns-ms-stubbing:
+    image: cdcgov/fdns-ms-stubbing
+    ports:
+      - "3002:3002" 

--- a/src/main/java/gov/cdc/foundation/controller/CDAController.java
+++ b/src/main/java/gov/cdc/foundation/controller/CDAController.java
@@ -6,7 +6,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.log4j.Logger;
-import org.json.JSONArray;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -18,7 +17,6 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -65,8 +63,14 @@ public class CDAController {
 		}
 	}
 
-	@RequestMapping(value = "json", method = RequestMethod.POST)
-	@ApiOperation(value = "Transform CDA to JSON", notes = "Transforms a CDA message to JSON object.")
+	@RequestMapping(
+		value = "json",
+		method = RequestMethod.POST
+	)
+	@ApiOperation(
+		value = "Transform CDA to JSON",
+		notes = "Transforms a CDA message to JSON object."
+	)
 	@ResponseBody
 	public ResponseEntity<?> transformCDAtoJSON(@RequestBody(required = true) String message) {
 		ObjectMapper mapper = new ObjectMapper();
@@ -89,11 +93,17 @@ public class CDAController {
 		}
 	}
 
-	@RequestMapping(value = "generate", method = RequestMethod.GET, produces = MediaType.APPLICATION_XML_VALUE)
-	@ApiOperation(value = "Generate random CDA message", notes = "Generates a random CDA message. All names, characters, and incidents generated when calling this API are fictitious. No identification with actual persons (living or deceased), places, buildings, and products is intended or should be inferred. Any resemblance to real persons, living or dead, is purely coincidental.")
+	@RequestMapping(
+		value = "generate",
+		method = RequestMethod.GET,
+		produces = MediaType.APPLICATION_XML_VALUE
+	)
+	@ApiOperation(
+		value = "Generate random CDA message",
+		notes = "Generates a random CDA message. All names, characters, and incidents generated when calling this API are fictitious. No identification with actual persons (living or deceased), places, buildings, and products is intended or should be inferred. Any resemblance to real persons, living or dead, is purely coincidental."
+	)
 	@ResponseBody
 	public ResponseEntity<?> generate() {
-
 		Map<String, Object> log = new HashMap<>();
 		log.put(MessageHelper.CONST_METHOD, MessageHelper.METHOD_GENERATE);
 

--- a/src/main/java/gov/cdc/foundation/security/OAuth2Configuration.java
+++ b/src/main/java/gov/cdc/foundation/security/OAuth2Configuration.java
@@ -35,7 +35,7 @@ public class OAuth2Configuration extends ResourceServerConfigurerAdapter {
 				.authorizeRequests()
 				.antMatchers(HttpMethod.OPTIONS).permitAll()
 				.antMatchers("/api/1.0/").permitAll()
-				.antMatchers(protectedURIs).access("#oauth2.hasScope('cda-utils')")
+				.antMatchers(protectedURIs).access("#oauth2.hasScope('fdns.cda-utils')")
 				.anyRequest().permitAll();
 		else
 			http

--- a/src/test/java/gov/cdc/foundation/CdaApplicationTests.java
+++ b/src/test/java/gov/cdc/foundation/CdaApplicationTests.java
@@ -30,9 +30,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, properties = { 
-		"logging.fluentd.host=localhost", 
+		"logging.fluentd.host=fluentd", 
 		"logging.fluentd.port=24224",
-		"proxy.hostname=localhost",
+		"proxy.hostname=",
 		"security.oauth2.resource.user-info-uri=",
 		"security.oauth2.protected=",
 		"security.oauth2.client.client-id=",

--- a/src/test/java/gov/cdc/foundation/OAuth2Test.java
+++ b/src/test/java/gov/cdc/foundation/OAuth2Test.java
@@ -10,33 +10,59 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
+import gov.cdc.helper.RequestHelper;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, properties = { 
-		"logging.fluentd.host=localhost", 
+		"logging.fluentd.host=fluentd",
 		"logging.fluentd.port=24224",
-		"proxy.hostname=localhost",
-		"security.oauth2.resource.user-info-uri=",
-		"security.oauth2.protected=/**",
-		"security.oauth2.client.client-id=",
-		"security.oauth2.client.client-secret=",
+		"proxy.hostname=",
+		"security.oauth2.resource.user-info-uri=http://fdns-ms-stubbing:3002/oauth2/token/introspect",
+		"security.oauth2.protected=/api/1.0/**",
+		"security.oauth2.client.client-id=test",
+		"security.oauth2.client.client-secret=testsecret",
 		"ssl.verifying.disable=false"})
 public class OAuth2Test {
 
 	@Autowired
 	private TestRestTemplate restTemplate;
 	private String baseUrlPath = "/api/1.0/";
+	private String testToken = "Bearer testtoken";
 
 	@Test
-	public void indexPage() {
-		ResponseEntity<String> response = this.restTemplate.getForEntity(baseUrlPath, String.class);
-		assertThat(response.getStatusCodeValue()).isEqualTo(200);
+	public void testUnauthenticated() {
+		ResponseEntity<String> response = this.restTemplate.getForEntity(baseUrlPath + "generate", String.class);
+		assertThat(response.getStatusCodeValue()).isEqualTo(401);
 	}
 
 	@Test
-	public void generatePage() {
-		ResponseEntity<String> response = this.restTemplate.getForEntity(baseUrlPath + "generate", String.class);
-		assertThat(response.getStatusCodeValue()).isEqualTo(401);
+	public void testAthenticated() throws Exception {
+		setScope("fdns.cda-utils");
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.add("Authorization", testToken);
+		HttpEntity<String> request = new HttpEntity<String>("{}", headers);
+
+		ResponseEntity<String> response = this.restTemplate.exchange(
+			baseUrlPath + "generate",
+			HttpMethod.GET,
+			request,
+			String.class
+		);
+
+		assertThat(response.getStatusCodeValue()).isEqualTo(200);
+	}
+
+	private void setScope(String scope) {
+		MultiValueMap<String, String> data = new LinkedMultiValueMap<>();
+		data.add("scope", scope);
+		RequestHelper.getInstance().executePost("http://fdns-ms-stubbing:3002/oauth2/mock", data);
 	}
 
 }


### PR DESCRIPTION
This pull request proposes a few changes:

- Changing the scopes to fall under a `fdns.*` namespace
- Adds support for CRUD operations (create, read, update and delete) and appends it at the end of the scope
- Adds support for wildcard scopes
- Adds the new https://github.com/CDCgov/fdns-ms-stubbing service for unit testing and tests OAuth 2.0 functionality

This pull request also proposes a change to using a gitlab-runner shell executor. Future improvements could be made to have multiple versions for different gitlab executors.

This also adds `docker-compose pull` as `docker-compose up` does not get the latest if the image already exists.